### PR TITLE
fix(drag): detect window drag more strictly

### DIFF
--- a/src/lib/navbar.svelte
+++ b/src/lib/navbar.svelte
@@ -68,37 +68,41 @@
     console.log(`navigate to url: ${url}`);
     window.prompt(`NAVIGATE_TO:${url}`);
   }
-  function onStartDragWindow(ev: MouseEvent) {
-    // on mac, this drag should fire before the window drag, otherwise it crash.
-    if (isMac && ev.buttons === 1) {
-      console.log('dragging window');
-      window.prompt('DRAG_WINDOW');
-      return;
-    }
-
-    // on Linux, mouse release event will not fire after dragging window,
-    // so we need to ensure it's acatually dragging window. Otherwise, double click on panel will not work.
+  function onPanelMouseDown(ev: MouseEvent) {
+    /* Draggable window */
     if (ev.buttons === 1) {
+      // on macOS, this drag window must trigger before native drag happened, otherwise, it will crash.
+      if (isMac) {
+        console.log('dragging window');
+        window.prompt('DRAG_WINDOW');
+        return;
+      }
+
+      // on Linux, mouse release event will not fire after dragging window,
+      // so we need to ensure it's acatually dragging window. Otherwise, double click on panel will not work.
       console.log('start dragging window');
       startDragging = true;
     }
   }
-  function onMouseUp(ev: MouseEvent) {
-    // if left button is released and dragging is started, reset dragging state
+  function onPanelMouseUp(ev: MouseEvent) {
+    /* Draggable window */
+    // on Linux and Windows, if left mouse button is released and dragging is started, reset dragging state
     if ((ev.buttons & 1) === 0 && startDragging) {
+      console.log('cancel dragging window');
       startDragging = false;
     }
   }
   function onMouseMove(ev: MouseEvent) {
-    // on Linux, we use mouse move event to detect if the user is actually dragging window.
+    /* Draggable window */
+    // on Linux and Windows, we use mouse move event to detect if the user is actually dragging window.
     if (!isMac && startDragging) {
       console.log('dragging window');
       window.prompt('DRAG_WINDOW');
       startDragging = false;
     }
   }
-  function onDbClickPanel() {
-    console.log('double click panel');
+  function onPanelDbClick() {
+    console.log('double click on panel');
     window.prompt('DBCLICK_PANEL');
   }
 </script>
@@ -107,15 +111,15 @@
   class="navbar flex box-border w-full items-center gap-1"
   bind:this={navbarEl}
   on:mousemove={onMouseMove}
-  on:mousedown|self={onStartDragWindow}
-  on:mouseup|self={onMouseUp}
-  on:dblclick|self={onDbClickPanel}
+  on:mousedown|self={onPanelMouseDown}
+  on:mouseup|self={onPanelMouseUp}
+  on:dblclick|self={onPanelDbClick}
 >
   <div
     class="flex flex-1 justify-between gap-1"
-    on:mousedown|self={onStartDragWindow}
-    on:mouseup|self={onMouseUp}
-    on:dblclick|self={onDbClickPanel}
+    on:mousedown|self={onPanelMouseDown}
+    on:mouseup|self={onPanelMouseUp}
+    on:dblclick|self={onPanelDbClick}
   >
     <div>
       <NavBtn on:click={onClickPrev} icon={PrevPageIcon} />
@@ -135,9 +139,9 @@
   </div>
   <div
     class="flex flex-1 justify-between gap-1"
-    on:mousedown|self={onStartDragWindow}
-    on:mouseup|self={onMouseUp}
-    on:dblclick|self={onDbClickPanel}
+    on:mousedown|self={onPanelMouseDown}
+    on:mouseup|self={onPanelMouseUp}
+    on:dblclick|self={onPanelDbClick}
   >
     <div>
       <NavBtn on:click={onClickRefresh} icon={RefreshIcon} />

--- a/src/lib/navbar.svelte
+++ b/src/lib/navbar.svelte
@@ -16,6 +16,9 @@
   // Window Dragging
   let startDragging: boolean = false;
 
+  // System information
+  const isMac = window.navigator.userAgent.includes('Mac');
+
   // Inject navbar function into global window object. Expose functions to backend.
   Object.assign(window, {
     navbar: {
@@ -26,7 +29,7 @@
   });
 
   onMount(() => {
-    if (window.navigator.userAgent.includes('Mac')) {
+    if (isMac) {
       navbarEl?.classList.add('macos');
     }
   });
@@ -66,7 +69,17 @@
     window.prompt(`NAVIGATE_TO:${url}`);
   }
   function onStartDragWindow(ev: MouseEvent) {
+    // on mac, this drag should fire before the window drag, otherwise it crash.
+    if (isMac && ev.buttons === 1) {
+      console.log('dragging window');
+      window.prompt('DRAG_WINDOW');
+      return;
+    }
+
+    // on Linux, mouse release event will not fire after dragging window,
+    // so we need to ensure it's acatually dragging window. Otherwise, double click on panel will not work.
     if (ev.buttons === 1) {
+      console.log('start dragging window');
       startDragging = true;
     }
   }
@@ -77,7 +90,9 @@
     }
   }
   function onMouseMove(ev: MouseEvent) {
-    if (startDragging) {
+    // on Linux, we use mouse move event to detect if the user is actually dragging window.
+    if (!isMac && startDragging) {
+      console.log('dragging window');
       window.prompt('DRAG_WINDOW');
       startDragging = false;
     }

--- a/src/lib/navbar.svelte
+++ b/src/lib/navbar.svelte
@@ -13,6 +13,9 @@
   let navbarEl: HTMLDivElement | null = null;
   let url = '';
 
+  // Window Dragging
+  let startDragging: boolean = false;
+
   // Inject navbar function into global window object. Expose functions to backend.
   Object.assign(window, {
     navbar: {
@@ -28,7 +31,7 @@
     }
   });
 
-  // Event handlers
+  /* Event handlers */
 
   function onClickPrev() {
     console.log('click prev');
@@ -62,10 +65,21 @@
     console.log(`navigate to url: ${url}`);
     window.prompt(`NAVIGATE_TO:${url}`);
   }
-  function onDragWindow(ev: MouseEvent) {
+  function onStartDragWindow(ev: MouseEvent) {
     if (ev.buttons === 1) {
-      console.log('drag window');
+      startDragging = true;
+    }
+  }
+  function onMouseUp(ev: MouseEvent) {
+    // if left button is released and dragging is started, reset dragging state
+    if ((ev.buttons & 1) === 0 && startDragging) {
+      startDragging = false;
+    }
+  }
+  function onMouseMove(ev: MouseEvent) {
+    if (startDragging) {
       window.prompt('DRAG_WINDOW');
+      startDragging = false;
     }
   }
   function onDbClickPanel() {
@@ -77,12 +91,15 @@
 <div
   class="navbar flex box-border w-full items-center gap-1"
   bind:this={navbarEl}
-  on:mousedown|self={onDragWindow}
+  on:mousemove={onMouseMove}
+  on:mousedown|self={onStartDragWindow}
+  on:mouseup|self={onMouseUp}
   on:dblclick|self={onDbClickPanel}
 >
   <div
     class="flex flex-1 justify-between gap-1"
-    on:mousedown|self={onDragWindow}
+    on:mousedown|self={onStartDragWindow}
+    on:mouseup|self={onMouseUp}
     on:dblclick|self={onDbClickPanel}
   >
     <div>
@@ -103,7 +120,8 @@
   </div>
   <div
     class="flex flex-1 justify-between gap-1"
-    on:mousedown|self={onDragWindow}
+    on:mousedown|self={onStartDragWindow}
+    on:mouseup|self={onMouseUp}
     on:dblclick|self={onDbClickPanel}
   >
     <div>


### PR DESCRIPTION
**Root cause**
- We detect window drag by pressing the left mouse button
- We also detect double-clicking (press-release-press-release) to maximize the window.
- On Linux (Wayland), the release event will not be emitted after window drag. (PRESS EVENT->[trigger drag]->NO RELEASE EVENT). Hence, no release and click event will be emitted from the panel, and double-clicking to maximize the window will not work.

**Fix**
- On Linux and Windows, we added a new state `start_dragging` with mouse move event to validate it's actually a drag event, and then invokes winit's drag window.
- On macOS, since the top area is handled by the OS itself, it seemed that an additional invokes of drag_window would crash the app. We need to invoke the `drag_window` before the OS intercepts.